### PR TITLE
fix: update compile section

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
           HUGO_ENV: production
         run: |
           npm i -D postcss postcss-cli autoprefixer
-          hugo mod get
           hugo --minify
       # copy .asf.yaml to ./public, asf site needs it.
       - run: cp .asf.yaml ./public

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,16 +13,17 @@ on:
       - "**.md"
       - ".github/workflows/**"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
-        with:
-          node-version: "14"
       - name: Prettier check
         run: |
           # if you encounter error, rerun the command below and commit the changes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,3 +28,16 @@ jobs:
           # if you encounter error, rerun the command below and commit the changes
           make lint
           git diff --exit-code
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v3
+        with:
+          hugo-version: 'latest'
+          extended: true
+      - name: Build with Hugo
+        env:
+          # For maximum backward compatibility with Hugo modules
+          HUGO_ENVIRONMENT: production
+          HUGO_ENV: production
+        run: |
+          npm i -D postcss postcss-cli autoprefixer
+          hugo --minify

--- a/README.md
+++ b/README.md
@@ -8,14 +8,9 @@
 
 This repository stores all the source files of [HoraeDB website](https://horaedb.apache.org), it's built with [hugo](https://gohugo.io/) and [docsy](https://www.docsy.dev/).
 
-**All files are written in standard markdown.**
-
 ## How to run
 
 ```bash
-# Download dependencies, only need to run at the first time
-hugo mod get
-
 # Start a local server for preview
 hugo serve
 ```

--- a/content/cn/docs/dev/compile_run.md
+++ b/content/cn/docs/dev/compile_run.md
@@ -5,7 +5,9 @@ weight: 10
 
 为了编译 HoraeDB, 首先需要安装相关的依赖（包括 `Rust` 的工具链)。
 
-# 依赖(Ubuntu20.04)
+# 依赖
+
+## Ubuntu
 
 假设我们的开发环境是 Ubuntu20.04, 可以执行如下命令来安装所需的依赖。
 
@@ -13,11 +15,9 @@ weight: 10
 sudo apt install git curl gcc g++ libssl-dev pkg-config cmake protobuf-compiler
 ```
 
-需要注意的是，项目的编译对 cmake、gcc、g++等依赖项有版本要求。
+需要注意的是，项目的编译对 cmake 有版本要求。如果你的开发环境是旧的 Linux 发行版，有必要手动安装这些依赖项的高版本。
 
-如果你的开发环境是旧的 Linux 发行版，有必要手动安装这些依赖项的高版本。
-
-# 依赖(MacOS)
+## macOS
 
 如果你的开发环境是 `MacOS` ，可以使用如下命令手动安装这些依赖项的高版本。
 
@@ -52,16 +52,14 @@ source $HOME/.cargo/env
 
 # 编译运行
 
-注意：gcc 版本要求是 8, 更高的版本可能出现编译报错。该问题在 [issue-1506](https://github.com/apache/incubator-horaedb/issues/1506) 中跟进。
-
 编译 HoraeDB 命令如下:
 
 ```
-cargo build --release
+cargo build
 ```
 
 然后可以使用特定的配置文件运行 HoraeDB。
 
 ```bash
-./target/release/horaedb-server --config ./docs/minimal.toml
+./target/debug/horaedb-server --config ./docs/minimal.toml
 ```

--- a/content/en/docs/dev/compile_run.md
+++ b/content/en/docs/dev/compile_run.md
@@ -5,7 +5,9 @@ weight: 30
 
 In order to compile HoraeDB, some relevant dependencies(including the `Rust` toolchain) should be installed.
 
-# Dependencies(Ubuntu20.04)
+# Dependencies
+
+## Ubuntu
 
 Assuming the development environment is Ubuntu20.04, execute the following command to install the required dependencies:
 
@@ -13,9 +15,9 @@ Assuming the development environment is Ubuntu20.04, execute the following comma
 sudo apt install git curl gcc g++ libssl-dev pkg-config cmake protobuf-compiler
 ```
 
-It should be noted that the compilation of the project has version requirements for dependencies such as cmake, gcc, g++, etc. If your development environment is an old Linux distribution, it is necessary to manually install these dependencies of a higher version.
+It should be noted that the compilation of the project requires a higher version of CMake; if your development environment is an older Linux distribution, you will need to manually install the dependencies for a higher version.
 
-# Dependencies(MacOS)
+## macOS
 
 If the development environment is MacOS, execute the following command to install the required dependencies.
 
@@ -49,16 +51,14 @@ source $HOME/.cargo/env
 
 # Compile and Run
 
-Note: The gcc version required is 8; using higher versions may result in compilation errors. This issue is being tracked in [issue-1506](https://github.com/apache/incubator-horaedb/issues/1506).
-
 Compile HoraeDB by the following command:
 
 ```
-cargo build --release
+cargo build
 ```
 
 Then you can run HoraeDB using the default configuration file provided in the codebase.
 
 ```bash
-./target/release/horaedb-server --config ./docs/minimal.toml
+./target/debug/horaedb-server --config ./docs/minimal.toml
 ```

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/apache/horaedb-docs
 
 go 1.22
 
-require github.com/google/docsy v0.10.0 // indirect
+require github.com/google/docsy v0.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,7 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20240402185447-c0f460dca7f7/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240716171331-37eff7fa00de/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.10.0 h1:6tMDacPwAyRWNCfvsn/9qGOZDQ8b0aRzjRZvnZPY5dg=
 github.com/google/docsy v0.10.0/go.mod h1:c0nIAqmRTOuJ01F85U/wJPQtc3Zj9N58Kea9bOT2AJc=
+github.com/google/docsy v0.11.0 h1:QnV40cc28QwS++kP9qINtrIv4hlASruhC/K3FqkHAmM=
+github.com/google/docsy v0.11.0/go.mod h1:hGGW0OjNuG5ZbH5JRtALY3yvN8ybbEP/v2iaK4bwOUI=
 github.com/twbs/bootstrap v5.3.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=


### PR DESCRIPTION
RocksDB is not required by default when build horaedb-server, so we don't specific version of gcc.