### PR TITLE
source code download link should use closer.lua link

### DIFF
--- a/content/cn/downloads.md
+++ b/content/cn/downloads.md
@@ -11,7 +11,7 @@ Apache HoraeDB 使用源码压缩包进行发布。
 
 # 最新发布
 
-最新一次发布版本：2.1.0(2024-11-18)，源码[下载地址](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz)。
+最新一次发布版本：2.1.0(2024-11-18)，源码[下载地址](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz?action=download)。
 
 用户可以按照以下指南使用 [signatures](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.asc) 和 [checksums](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.sha512) 验证此版本。
 

--- a/content/cn/downloads.md
+++ b/content/cn/downloads.md
@@ -11,7 +11,7 @@ Apache HoraeDB 使用源码压缩包进行发布。
 
 # 最新发布
 
-最新一次发布版本：2.1.0(2024-11-18)，源码[下载地址](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz)。
+最新一次发布版本：2.1.0(2024-11-18)，源码[下载地址](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz)。
 
 用户可以按照以下指南使用 [signatures](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.asc) 和 [checksums](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.sha512) 验证此版本。
 
@@ -24,7 +24,7 @@ Apache HoraeDB 使用源码压缩包进行发布。
 
 ## 历史版本
 
-历史已发布版本，可以在[这里](https://downloads.apache.org/incubator/horaedb/horaedb/)查询得到。
+历史已发布版本，可以在[这里](https://archive.apache.org/dist/incubator/horaedb/horaedb/)查询得到。
 
 # 验证 signatures 和 checksums
 

--- a/content/en/downloads.md
+++ b/content/en/downloads.md
@@ -13,7 +13,7 @@ Apache HoraeDB server is released as source code tarballs with corresponding doc
 
 ### The latest release
 
-The latest release is 2.1.0(2024-11-18), the source code can be downloaded [here](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz).
+The latest release is 2.1.0(2024-11-18), the source code can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz).
 
 Verify this release using the [signatures](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.asc), [checksums](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.sha512) by following guides below.
 
@@ -26,13 +26,13 @@ Pre-built binaries are not provided yet, users can [compile from source]({{< ref
 
 ### All archived releases
 
-For older releases, please check the [archive](https://downloads.apache.org/incubator/horaedb/horaedb/).
+For older releases, please check the [archive](https://archive.apache.org/dist/incubator/horaedb/horaedb/).
 
 ## Client
 
 ### Rust
 
-The latest rust client version is v2.0.0(2024-07-11), source codes can be downloaded [here](https://downloads.apache.org/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz), release note is [here](https://github.com/apache/horaedb-client-rs/releases/tag/v2.0.0).
+The latest rust client version is v2.0.0(2024-07-11), source codes can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz), release note is [here](https://github.com/apache/horaedb-client-rs/releases/tag/v2.0.0).
 
 Verify this release using the [signatures](https://downloads.apache.org/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz.asc), [checksums](https://downloads.apache.org/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz.sha512) by following guides below.
 
@@ -40,7 +40,7 @@ It's also available on [crates.io](https://crates.io/crates/horaedb-client).
 
 ### Python
 
-The latest python client version is v2.0.0(2024-12-10), source codes can be downloaded [here](https://downloads.apache.org/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz), release note is [here](https://github.com/apache/horaedb-client-py/releases/tag/v2.0.0).
+The latest python client version is v2.0.0(2024-12-10), source codes can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz), release note is [here](https://github.com/apache/horaedb-client-py/releases/tag/v2.0.0).
 
 Verify this release using the [signatures](https://downloads.apache.org/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz.asc), [checksums](https://downloads.apache.org/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz.sha512) by following guides below.
 

--- a/content/en/downloads.md
+++ b/content/en/downloads.md
@@ -13,7 +13,7 @@ Apache HoraeDB server is released as source code tarballs with corresponding doc
 
 ### The latest release
 
-The latest release is 2.1.0(2024-11-18), the source code can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz).
+The latest release is 2.1.0(2024-11-18), the source code can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz?action=download).
 
 Verify this release using the [signatures](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.asc), [checksums](https://downloads.apache.org/incubator/horaedb/horaedb/v2.1.0/apache-horaedb-incubating-v2.1.0-src.tar.gz.sha512) by following guides below.
 
@@ -32,7 +32,7 @@ For older releases, please check the [archive](https://archive.apache.org/dist/i
 
 ### Rust
 
-The latest rust client version is v2.0.0(2024-07-11), source codes can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz), release note is [here](https://github.com/apache/horaedb-client-rs/releases/tag/v2.0.0).
+The latest rust client version is v2.0.0(2024-07-11), source codes can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz?action=download), release note is [here](https://github.com/apache/horaedb-client-rs/releases/tag/v2.0.0).
 
 Verify this release using the [signatures](https://downloads.apache.org/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz.asc), [checksums](https://downloads.apache.org/incubator/horaedb/horaedb-client-rust/v2.0.0/apache-horaedb-incubating-rust-client-v2.0.0-src.tar.gz.sha512) by following guides below.
 
@@ -40,7 +40,7 @@ It's also available on [crates.io](https://crates.io/crates/horaedb-client).
 
 ### Python
 
-The latest python client version is v2.0.0(2024-12-10), source codes can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz), release note is [here](https://github.com/apache/horaedb-client-py/releases/tag/v2.0.0).
+The latest python client version is v2.0.0(2024-12-10), source codes can be downloaded [here](https://www.apache.org/dyn/closer.lua/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz?action=download), release note is [here](https://github.com/apache/horaedb-client-py/releases/tag/v2.0.0).
 
 Verify this release using the [signatures](https://downloads.apache.org/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz.asc), [checksums](https://downloads.apache.org/incubator/horaedb/horaedb-client-python/v2.0.0/apache-horaedb-incubating-python-client-v2.0.0-src.tar.gz.sha512) by following guides below.
 


### PR DESCRIPTION
See https://lists.apache.org/thread/8w4wcn63cmwqz7htjqtjkwcst76h8ycl

> must have at least one link to the current release. This link must use the closer.lua utility. For example: https://www.apache.org/dyn/closer.lua/PROJECT/VERSION/SOURCE-RELEASE. (Note: the mirrors.cgi and closer.cgi scripts have been deprecated. Calls to them redirect to closer.lua.)

> https://infra.apache.org/release-download-pages.html#download-page